### PR TITLE
add templates for mysql, es and redis to dashboard gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,11 @@ Take the datasource Prometheus for example, KubeSphere backend will add a namesp
 
 ### Dashboard Template
 
-Dashboard is represented by a custom resource object. A dashboard template is any dashboard labeled with `dashboard.monitoring.kubesphere.io/template: true`. Dashboard templates are ready-made and portable. They can be shared across the cluster or to specific namespaces. Before sharing, remember to remove confidential content. 
+Dashboard is represented by a custom resource object. Select templates from [contrib/gallery](contrib/gallery), and run the following command to import:
 
-There are two types of dashboard templates:
-
-- **cluster-scoped**: dashboard templates in the namespace `kubesphere-monitoring-system`
-- **namespace-scoped**: those in private namespaces
+```
+kubectl apply --namespace <NAMESPACE> -f contrib/gallery/<TEMPLATE_YAML_FILE>
+```
 
 You can also open source your template and contribute to Dashboard Gallery. Templates in Dashboard Gallery will be shipped with KubeSphere.
 

--- a/contrib/gallery/elasticsearch.yaml
+++ b/contrib/gallery/elasticsearch.yaml
@@ -1,0 +1,463 @@
+apiVersion: monitoring.kubesphere.io/v1alpha1
+kind: Dashboard
+metadata:
+  name: elasticsearch-overview
+spec:
+  datasource: prometheus
+  description: ""
+  panels:
+    - decimals: 0
+      format: none
+      id: 11
+      targets:
+        - expr: sum by(cluster) (elasticsearch_cluster_health_status{color="red"})
+      title: Red Clusters
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 12
+      targets:
+        - expr: sum by(cluster) (elasticsearch_cluster_health_status{color="yellow"})
+      title: Yellow Clusters
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 14
+      targets:
+        - expr: elasticsearch_cluster_health_number_of_nodes
+      title: Number of Nodes
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 16
+      targets:
+        - expr: elasticsearch_cluster_health_number_of_data_nodes
+      title: Number of Data Nodes
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 17
+      targets:
+        - expr: elasticsearch_cluster_health_number_of_pending_tasks
+      title: Pending Tasks
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 21
+      targets:
+        - expr: sum (elasticsearch_process_open_files_count)
+      title: Open File Descriptors
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 22
+      targets:
+        - expr: elasticsearch_cluster_health_active_primary_shards
+      title: Active primary shards
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 25
+      targets:
+        - expr: elasticsearch_cluster_health_active_shards
+      title: Active shards
+      type: singlestat
+      valueName: last
+    - id: 37
+      title: JVM
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 15
+      lines: true
+      stack: false
+      targets:
+        - expr: sum by(name) (elasticsearch_jvm_memory_used_bytes) / sum by(name) (elasticsearch_jvm_memory_max_bytes)
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: JVM Memory Used
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: percent (0.0-1.0)
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 30
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_jvm_memory_committed_bytes
+          legendFormat: '{{name}} committed: {{area}}'
+          refId: 1
+          step: 1m
+        - expr: elasticsearch_jvm_memory_max_bytes
+          legendFormat: '{{name}} max: {{area}}'
+          refId: 2
+          step: 1m
+      title: JVM Memory Committed
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: Byte
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 27
+      lines: true
+      stack: false
+      targets:
+        - expr: irate(elasticsearch_jvm_gc_collection_seconds_count[3m])
+          legendFormat: '{{name}} {{gc}}'
+          refId: 1
+          step: 1m
+      title: GC Count
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 28
+      lines: true
+      stack: false
+      targets:
+        - expr: irate(elasticsearch_jvm_gc_collection_seconds_sum[3m])
+          legendFormat: '{{name}} {{gc}}'
+          refId: 1
+          step: 1m
+      title: GC Time
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: none
+    - id: 38
+      title: Resource Consumption
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 29
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_os_load1
+          legendFormat: 'load1: {{name}}'
+          refId: 1
+          step: 1m
+        - expr: elasticsearch_os_load5
+          legendFormat: 'load5: {{name}}'
+          refId: 2
+          step: 1m
+        - expr: elasticsearch_os_load15
+          legendFormat: 'load15: {{name}}'
+          refId: 3
+          step: 1m
+      title: Load Average
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 32
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_filesystem_data_available_bytes
+          legendFormat: '{{name}}: {{path}}'
+          refId: 1
+          step: 1m
+      title: Disk Usage
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: Byte
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 33
+      lines: true
+      stack: false
+      targets:
+        - expr: irate(elasticsearch_transport_tx_size_bytes_total[3m])
+          legendFormat: '{{name}}: sent'
+          refId: 1
+          step: 1m
+        - expr: irate(elasticsearch_transport_rx_size_bytes_total[3m])
+          legendFormat: '{{name}}: received'
+          refId: 2
+          step: 1m
+      title: Network Usage
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: Byte
+    - id: 39
+      title: Documents and Indices
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 34
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_indices_docs
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Documents Count on Node
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 26
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_cluster_health_initializing_shards
+          legendFormat: Initializing Shards
+          refId: 1
+          step: 1m
+        - expr: elasticsearch_cluster_health_relocating_shards
+          legendFormat: Relocating Shards
+          refId: 2
+          step: 1m
+        - expr: elasticsearch_cluster_health_active_shards
+          legendFormat: Active Shards
+          refId: 3
+          step: 1m
+        - expr: elasticsearch_cluster_health_active_primary_shards
+          legendFormat: Active Primary Shards
+          refId: 4
+          step: 1m
+        - expr: elasticsearch_cluster_health_unassigned_shards
+          legendFormat: Unassigned Shards
+          refId: 5
+          step: 1m
+        - expr: elasticsearch_cluster_health_delayed_unassigned_shards
+          legendFormat: Delayed Unassigned Shards
+          refId: 6
+          step: 1m
+      title: Shards
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 35
+      lines: true
+      stack: false
+      targets:
+        - expr: 'irate(elasticsearch_indices_search_query_time_seconds[3m]) '
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Query Time
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 42
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_indices_query_cache_memory_size_bytes
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Query Cache Size
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: Byte
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 36
+      lines: true
+      stack: false
+      targets:
+        - expr: irate(elasticsearch_indices_indexing_index_time_seconds_total[5m])
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Indexing Time
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 43
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_indices_segments_count
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Count of Index Segments
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 44
+      lines: true
+      stack: false
+      targets:
+        - expr: elasticsearch_indices_segments_memory_bytes
+          legendFormat: '{{name}}'
+          refId: 1
+          step: 1m
+      title: Current Memory of Segments
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: Byte
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: Total size of stored index data in bytes with all shards on all nodes
+      id: 45
+      lines: true
+      stack: false
+      targets:
+        - expr: sum by(index) (elasticsearch_indices_store_size_bytes_total)
+          legendFormat: '{{index}}'
+          refId: 1
+          step: 1m
+      title: Total Size Stored Index Data
+      type: graph
+      yaxes:
+        - decimals: 3
+          format: Byte
+  title: Elasticsearch Overview

--- a/contrib/gallery/mysql.yaml
+++ b/contrib/gallery/mysql.yaml
@@ -1,0 +1,372 @@
+apiVersion: monitoring.kubesphere.io/v1alpha1
+kind: Dashboard
+metadata:
+  name: mysql-overview
+spec:
+  datasource: prometheus
+  description: ""
+  panels:
+    - decimals: 2
+      format: none
+      id: 2
+      targets:
+        - expr: mysql_global_status_uptime / (3600*24)
+      title: MySQL Uptime (days)
+      type: singlestat
+      valueName: last
+    - decimals: 2
+      format: none
+      id: 3
+      targets:
+        - expr: rate(mysql_global_status_queries[5m]) or irate(mysql_global_status_queries[5m])
+      title: Current QPS
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: Byte
+      id: 6
+      targets:
+        - expr: mysql_global_variables_innodb_buffer_pool_size
+      title: InnoDB Buffer Pool Size
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 9
+      targets:
+        - expr: mysql_global_variables_max_connections
+      title: Max Permitted Connections
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 12
+      targets:
+        - expr: mysql_global_variables_thread_cache_size
+      title: Thread Cache Size
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 21
+      targets:
+        - expr: mysql_global_variables_long_query_time
+      title: Long Query Time (second)
+      type: singlestat
+      valueName: last
+    - id: 4
+      title: Connections and Threads
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: The maximum number of connections that have been in use simultaneously
+        since the server started.
+      id: 8
+      lines: true
+      stack: false
+      targets:
+        - expr: mysql_global_status_max_used_connections
+          legendFormat: Max Used Connections
+          refId: 1
+          step: 1m
+      title: Connections
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: 'Threads Cached: The number of threads in the thread cache. Threads
+      Connected: The number of currently open connections. Threads Created: The number
+      of threads created to handle connections. Threads Running: The number of threads
+      that are not sleeping.'
+      id: 5
+      lines: true
+      stack: false
+      targets:
+        - expr: mysql_global_status_threads_connected
+          legendFormat: Threads Connected
+          refId: 1
+          step: 1m
+        - expr: mysql_global_status_threads_created
+          legendFormat: Threads Created
+          refId: 2
+          step: 1m
+        - expr: mysql_global_status_threads_running
+          legendFormat: Threads Running
+          refId: 3
+          step: 1m
+        - expr: mysql_global_status_threads_cached
+          legendFormat: Threads Cached
+          refId: 4
+          step: 1m
+      title: Threads
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: 'Aborted_clients: The number of connections that were aborted because
+      the client died without closing the connection properly. Aborted_connects: The
+      number of failed attempts to connect to the MySQL server.'
+      id: 22
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_aborted_connects[5m]) or irate(mysql_global_status_aborted_connects[5m])
+          legendFormat: Aborted Connects (attempts)
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_aborted_clients[5m]) or irate(mysql_global_status_aborted_clients[5m])
+          legendFormat: Aborted Clients (timeout)
+          refId: 2
+          step: 1m
+      title: Aborted Connections
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - id: 10
+      title: Queries and Questions
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: The number of statements executed by the server. This includes only
+        statements sent to the server by clients and not statements executed within
+        stored programs, unlike the Queries variable.
+      id: 13
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_questions[5m]) or irate(mysql_global_status_questions[5m])
+          legendFormat: Questions
+          refId: 1
+          step: 1m
+      title: Questions
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 18
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_select_full_join[5m]) or irate(mysql_global_status_select_full_join[5m])
+          legendFormat: Full Join
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_select_full_range_join[5m]) or irate(mysql_global_status_select_full_range_join[5m])
+          legendFormat: Full Range Join
+          refId: 2
+          step: 1m
+        - expr: rate(mysql_global_status_select_scan[5m]) or irate(mysql_global_status_select_scan[5m])
+          legendFormat: Scan
+          refId: 3
+          step: 1m
+        - expr: rate(mysql_global_status_select_range[5m]) or irate(mysql_global_status_select_range[5m])
+          legendFormat: Range
+          refId: 4
+          step: 1m
+        - expr: rate(mysql_global_status_select_range_check[5m]) or irate(mysql_global_status_select_range_check[5m])
+          legendFormat: Range Check
+          refId: 5
+          step: 1m
+      title: Select By Types
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 19
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_sort_rows[5m]) or irate(mysql_global_status_sort_rows[5m])
+          legendFormat: Rows
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_sort_range[5m]) or irate(mysql_global_status_sort_range[5m])
+          legendFormat: Range
+          refId: 2
+          step: 1m
+        - expr: rate(mysql_global_status_sort_merge_passes[5m]) or irate(mysql_global_status_sort_merge_passes[5m])
+          legendFormat: Merge Passes
+          refId: 3
+          step: 1m
+        - expr: rate(mysql_global_status_sort_scan[5m]) or irate(mysql_global_status_sort_scan[5m])
+          legendFormat: Scan
+          refId: 4
+          step: 1m
+      title: Sort By Types
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: The number of queries that have taken more than long_query_time seconds.
+        This counter increments regardless of whether the slow query log is enabled.
+      id: 20
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_slow_queries[5m]) or irate(mysql_global_status_slow_queries[5m])
+          legendFormat: Slow Queries
+          refId: 1
+          step: 1m
+      title: Slow Queries
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - id: 15
+      title: Temporary Objects
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 16
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_created_tmp_tables[5m]) or irate(mysql_global_status_created_tmp_tables[5m])
+          legendFormat: Created Tmp Tables
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_created_tmp_disk_tables[5m]) or irate(mysql_global_status_created_tmp_disk_tables[5m])
+          legendFormat: Created Tmp Disk Tables
+          refId: 2
+          step: 1m
+        - expr: rate(mysql_global_status_created_tmp_files[5m]) or irate(mysql_global_status_created_tmp_files[5m])
+          legendFormat: Created Tmp Files
+          refId: 3
+          step: 1m
+      title: Tmp Tables and Files
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - id: 23
+      title: Table Locks
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: 'The number of times that a request for a table lock could be granted
+      immediately, or could not be granted immediately and a wait was needed. '
+      id: 24
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_table_locks_immediate[5m]) or irate(mysql_global_status_table_locks_immediate[5m])
+          legendFormat: Table Locks Immediate
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_table_locks_waited[5m]) or irate(mysql_global_status_table_locks_waited[5m])
+          legendFormat: Table Locks Waited
+          refId: 2
+          step: 1m
+      title: Locks By Types
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - id: 25
+      title: Network Traffic
+      type: row
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 26
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(mysql_global_status_bytes_received[5m]) or irate(mysql_global_status_bytes_received[5m])
+          legendFormat: Inbound
+          refId: 1
+          step: 1m
+        - expr: rate(mysql_global_status_bytes_sent[5m]) or irate(mysql_global_status_bytes_sent[5m])
+          legendFormat: Outbound
+          refId: 2
+          step: 1m
+      title: Inbound vs Outbound
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: Byte/s
+  title: MySQL Overview

--- a/contrib/gallery/redis.yaml
+++ b/contrib/gallery/redis.yaml
@@ -1,0 +1,218 @@
+apiVersion: monitoring.kubesphere.io/v1alpha1
+kind: Dashboard
+metadata:
+  name: redis-overview
+spec:
+  datasource: prometheus
+  description: ""
+  panels:
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 6
+      lines: true
+      stack: false
+      targets:
+        - expr: irate(redis_keyspace_hits_total[5m])
+          legendFormat: Hits
+          refId: 1
+          step: 1m
+        - expr: irate(redis_keyspace_misses_total[5m])
+          legendFormat: Misses
+          refId: 2
+          step: 1m
+      title: Hits / Misses per Sec
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 7
+      lines: true
+      stack: false
+      targets:
+        - expr: rate(redis_net_input_bytes_total[5m])
+          legendFormat: Input
+          refId: 1
+          step: 1m
+        - expr: rate(redis_net_output_bytes_total[5m])
+          legendFormat: Output
+          refId: 2
+          step: 1m
+      title: Network I/O
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: Byte/s
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 8
+      lines: true
+      stack: false
+      targets:
+        - expr: sum (redis_db_keys) by (db)
+          legendFormat: '{{db}}'
+          refId: 1
+          step: 1m
+      title: Total Items per DB
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 9
+      lines: true
+      stack: false
+      targets:
+        - expr: 'sum (redis_db_keys) - sum (redis_db_keys_expiring) '
+          legendFormat: Not Expiring
+          refId: 1
+          step: 1m
+        - expr: 'sum (redis_db_keys_expiring) '
+          legendFormat: Expiring
+          refId: 2
+          step: 1m
+      title: Expiring vs Not-Expiring Keys
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 10
+      lines: true
+      stack: false
+      targets:
+        - expr: sum(rate(redis_expired_keys_total[5m])) by (instance)
+          legendFormat: Expired
+          refId: 1
+          step: 1m
+        - expr: sum(rate(redis_evicted_keys_total[5m])) by (instance)
+          legendFormat: Evicted
+          refId: 2
+          step: 1m
+      title: Expired / Evicted
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 11
+      lines: true
+      stack: false
+      targets:
+        - expr: topk(5, irate(redis_commands_total[3m]))
+          legendFormat: '{{cmd}}'
+          refId: 1
+          step: 1m
+      title: Command Calls / sec
+      type: graph
+      yaxes:
+        - decimals: 2
+          format: none
+    - bars: false
+      colors:
+        - '#60acfc'
+        - '#23c2db'
+        - '#64d5b2'
+        - '#d5ec5a'
+        - '#ffb64e'
+        - '#fb816d'
+        - '#d15c7f'
+      description: ""
+      id: 12
+      lines: true
+      stack: false
+      targets:
+        - expr: redis_connected_clients
+          legendFormat: total
+          refId: 1
+          step: 1m
+      title: Redis connected clients
+      type: graph
+      yaxes:
+        - decimals: 0
+          format: none
+    - decimals: 2
+      format: none
+      id: 1
+      targets:
+        - expr: redis_uptime_in_seconds / (3600 * 24)
+      title: Uptime (days)
+      type: singlestat
+      valueName: last
+    - decimals: 0
+      format: none
+      id: 3
+      targets:
+        - expr: redis_connected_clients
+      title: Clients
+      type: singlestat
+      valueName: last
+    - decimals: 2
+      format: percent (0-100)
+      id: 4
+      targets:
+        - expr: redis_memory_used_bytes  / redis_memory_max_bytes
+      title: Memory Usage
+      type: singlestat
+      valueName: last
+    - decimals: 2
+      format: none
+      id: 5
+      targets:
+        - expr: rate(redis_commands_processed_total[2m])
+      title: Commands Executed / sec
+      type: singlestat
+      valueName: last
+  title: Redis Overview


### PR DESCRIPTION
Signed-off-by: huanggze <loganhuang@yunify.com>

Templates can be reviewed on dev. Issues related to frontend can be traced on  https://github.com/kubesphere/console/issues/276

### MySQL

![image](https://user-images.githubusercontent.com/22350668/83941150-ac81ea00-a81b-11ea-9a35-6570289a058d.png)

### Elasticsearch

![image](https://user-images.githubusercontent.com/22350668/83941163-ca4f4f00-a81b-11ea-8bdf-3d96b4acd322.png)

### Redis

![image](https://user-images.githubusercontent.com/22350668/83941168-ddfab580-a81b-11ea-9e6c-7b87102116ef.png)
