### PR TITLE
adjust converter APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ or:
 
 ### Integration with kubesphere backend
 
-In addition to the command line above, the method `ConvertFromJson` located at `tools/converter/dashboard_converter.go` can read bytes from Grafana dashboard templates, and convert it to two bytes types, including `OutputJson` and `OutputYaml`, therefore frontend developers can make visual presentations as needed.
+In addition to the command line above, the method `ConvertToDashboard` located at `tools/converter/dashboard_converter.go` can read bytes from Grafana dashboard templates, and convert to a `Dashboard` model, therefore the frontend developers can make visual presentations as needed.
 
 ## Development
 

--- a/tools/converter/dashboard_converter.go
+++ b/tools/converter/dashboard_converter.go
@@ -73,7 +73,7 @@ func (converter *Converter) ConvertToDashboard(content []byte, isClusterCrd bool
 
 }
 
-// ConvertKubsphereDashboardFromJson converts the input json content to json bytes content
+// ConvertDashboardToJson converts the input json content to json bytes content
 func (converter *Converter) ConvertDashboardToJson(content []byte, isClusterCrd bool, ns string, name string) error {
 	manifest, err := converter.ConvertToDashboard(content, isClusterCrd, ns, name)
 	if err != nil {
@@ -90,7 +90,7 @@ func (converter *Converter) ConvertDashboardToJson(content []byte, isClusterCrd 
 	return nil
 }
 
-// ConvertKubsphereDashboardFromJson converts the input json content to yaml bytes content
+// ConvertDashboardToYaml converts the input json content to yaml bytes content
 func (converter *Converter) ConvertDashboardToYaml(content []byte, isClusterCrd bool, ns string, name string) error {
 	err := converter.ConvertDashboardToJson(content, isClusterCrd, ns, name)
 	if err != nil {
@@ -107,7 +107,7 @@ func (converter *Converter) ConvertDashboardToYaml(content []byte, isClusterCrd 
 	return nil
 }
 
-// ConvertKubsphereDashboardFromFile converts the input json file to yaml/json bytes content
+// ConvertFromFile converts the input json file to yaml/json bytes content
 func (converter *Converter) ConvertFromFile(input io.Reader, isClusterCrd bool, ns string, name string) error {
 	content, err := ioutil.ReadAll(input)
 	if err != nil {
@@ -124,7 +124,7 @@ func (converter *Converter) ConvertFromFile(input io.Reader, isClusterCrd bool, 
 	return nil
 }
 
-// ConvertKubsphereDashboardManifests converts to a k8s mainfest file
+// ConvertToKubsphereDashboardManifests converts to a k8s mainfest file
 func (converter *Converter) ConvertToKubsphereDashboardManifests(input io.Reader, output io.Writer, isClusterCrd bool, ns string, name string) error {
 
 	err := converter.ConvertFromFile(input, isClusterCrd, ns, name)


### PR DESCRIPTION
Signed-off-by: zhu733756 <talonzhu@yunify.com>

This pr aims to adjust converter APIs for better integrating with KubeSphere/QKCP backend engine.
Features：
- Add function ConvertToDashboard.
- Split the serialization process for converting the dashboard model to JSON data.
- Split the logic for converting JSON data to Yaml data.

/cc @benjaminhuo @junotx 